### PR TITLE
Fixed issue with commanding multiple locks

### DIFF
--- a/index.js
+++ b/index.js
@@ -285,7 +285,7 @@ KevoAccessory.prototype.setState = function(state, callback) {
       setTimeout(function() {
         this.log("Setting status to %s", kevoStatus);
         this._setLockStatus(kevoStatus, lockStatusCallback);
-      }.bind(this), this.lockOrder * lockEventSpacing);
+      }.bind(this), lockEventsOccurring * lockEventSpacing);
     }
     else {
       lockEventsOccurring++;


### PR DESCRIPTION
The lock designated as lockOrder 0 was not always being commanded first. This led to the command being sent simultaneously with another lock and failing. The code has been updated to set the delay via lockEventsOccurring instead of the lockOrder, which has fixed the issue.