### PR TITLE
Add serial number to allow Home Assistant to import multiple locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,22 @@ Example config.json:
             "name": "Front Door",
             "username": "test@example.com",
             "password": "<your kevo password>",
-            "lock_id": "<your lock id>"
+            "lock_id": "<your lock id>",
+            "serialNumber": "<RANDOM STRING HERE>"
         },
         {
             "accessory": "Kevo",
             "name": "Back Door",
             "username": "test@example.com",
             "password": "<your kevo password>",
-            "lock_id": "<your lock id>"
+            "lock_id": "<your lock id>",
+            "serialNumber": "<RANDOM STRING HERE>"
         },
       ]
     }
 
-Kevo now provides the lock IDs from the web portal or app within the lock detail information. You can also find "lock_id" values by excluding lock_id from your config.json. When you start homebridge the next time, all "lock_id" values for your Kevo account will be printed in the logs.
+Kevo now provides the lock IDs from the web portal or app within the lock detail information. 
+
+Use a random serial number for each lock so that when importing to Home Assistant all locks come across instead of just one.
 
 NOTE: When commanding groups of locks, there will be a 15 second delay between each lock command firing because Kevo does not support rapid API requests. This causes Siri to usually say "Sorry x, I didn't hear back" as a result.

--- a/index.js
+++ b/index.js
@@ -19,10 +19,18 @@ function KevoAccessory(log, config) {
   this.username = config["username"];
   this.password = config["password"];
   this.lockId = config["lock_id"];
+  this.serialNumber = config["serialNumber"];
   this.lockOrder = lockOrder++;
-
-  this.service = new Service.LockMechanism(this.name);
+	
+	
+  this.informationService = new Service.AccessoryInformation();
+  this.informationService
+      .setCharacteristic(Characteristic.Manufacturer, 'Homebridge')
+      .setCharacteristic(Characteristic.Model, 'Kevo')
+      .setCharacteristic(Characteristic.SerialNumber, this.serialNumber);
   
+  this.service = new Service.LockMechanism(this.name);
+	
   this.service
     .getCharacteristic(Characteristic.LockCurrentState)
     .on('get', this.getState.bind(this));
@@ -35,6 +43,10 @@ function KevoAccessory(log, config) {
     .on('set', this.setState.bind(this));
   
   this._setup();
+}
+
+KevoAccessory.prototype.getServices = function() {
+  return [this.informationService, this.service];
 }
 
 KevoAccessory.prototype._setup = function() {
@@ -295,8 +307,4 @@ KevoAccessory.prototype.setState = function(state, callback) {
   
   }.bind(this));
 
-}
-
-KevoAccessory.prototype.getServices = function() {
-  return [this.service];
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "homebridge-kevo",
+  "name": "homebridge-kevo-withserial",
   "version": "0.0.10",
   "description": "Kevo support for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-kevo",
-  "version": "0.0.3",
+  "version": "0.0.10",
   "description": "Kevo support for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/nfarina/homebridge-kevo.git"
+    "url": "https://github.com/dpvu/homebridge-kevo-withserial"
   },
   "bugs": {
-    "url": "http://github.com/nfarina/homebridge-kevo/issues"
+    "url": "https://github.com/dpvu/homebridge-kevo-withserial/issues"
   },
   "engines": {
     "node": ">=0.12.0",


### PR DESCRIPTION
Home Assistant requires a unique serial number for each device or only one gets imported. Add ability to put a serial number in the config.